### PR TITLE
Added a concise note about GOOGLE_APPLICATION_CREDENTIALS for Gemini …

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ Then, run the gui with:
 denario run
 ```
 
-### credientials 
-**Note:** If you plan to use Gemini models, the app utilizes the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for authentication when accessing Gemini models via Vertex AI. See the [documentation on LLM API keys](https://denario.readthedocs.io/en/latest/llm_api_keys/) for setup instructions.
+### Credientials 
+
+See the [documentation on LLM API keys](https://denario.readthedocs.io/en/latest/llm_api_keys/) for setup instructions.
+
 
 ## Get started
 


### PR DESCRIPTION
Added a concise note about GOOGLE_APPLICATION_CREDENTIALS for Gemini models right after the installation instructions. As I initially ran, it threw Authentication errors. It will be helpful for users to know what they might need to have to run. 